### PR TITLE
input now attach itself to whatever set in the DUELLAppDelegate

### DIFF
--- a/backends/input_ios/project/Build.xml
+++ b/backends/input_ios/project/Build.xml
@@ -1,11 +1,11 @@
 <xml>
-	
+
 	<include name="${HXCPP}/build-tool/BuildCommon.xml"/>
-	
+
 	<files id="src">
-		
+		<include name="${haxelib:duell_duellbuildios}/native/native.xml" />
 		<compilerflag value="-Iinclude"/>
-		
+
 		<file name="src/InputCapturer.mm"/>
 		<file name="src/ExternalInterface.mm"/>
         <file name="src/DUELLGestureRecognizer.mm"/>
@@ -15,18 +15,18 @@
         <file name="src/TextFieldInterface.mm" />
 	</files>
 
-	
+
 	<target id="NDLL" output="${LIBPREFIX}inputios${DBG}${LIBEXTRA}" tool="linker" toolid="${STD_MODULE_LINK}">
-		
+
 		<outdir name="../ndll/${BINDIR}"/>
 		<files id="src"/>
-		
+
 	</target>
-	
+
 	<target id="default">
-		
+
 		<target id="NDLL"/>
-		
+
 	</target>
-	
+
 </xml>

--- a/backends/input_ios/project/src/InputCapturer.mm
+++ b/backends/input_ios/project/src/InputCapturer.mm
@@ -27,25 +27,18 @@
 #import <input_ios/InputCapturer.h>
 
 #import <input_ios/DUELLGestureRecognizer.h>
-
+#import "DUELLAppDelegate.h"
 @implementation InputCapturer
 
 + (void) initializeCapturer
 {
-	if ([UIApplication sharedApplication].keyWindow == nil)
+	DUELLAppDelegate *appDelegate = (DUELLAppDelegate *)[[UIApplication sharedApplication] delegate];
+	UIView *view = appDelegate.rootView;
+	if(view == nil)
 	{
-		@throw(@"Error: There is currently no window associated with this application. \
+		@throw(@"Error: There is currently no view set in the  DUELLAppDelegate. \
 			    Please initialize a library (e.g. opengl) that initializes a window, so the input library can attach to that.");
 	}
-
-	if ([UIApplication sharedApplication].keyWindow.rootViewController == nil)
-	{
-		@throw(@"Error: There is currently no root view controller associated with the key window. \
-			    Please initialize a library (e.g. opengl) that initializes a window, so the input library can attach to that.");
-	}
-
-	UIView *view = [UIApplication sharedApplication].keyWindow.rootViewController.view;
-
 	DUELLGestureRecognizer *recognizer = [[DUELLGestureRecognizer alloc] initWithTarget:nil action:nil];
     [view addGestureRecognizer:recognizer];
 


### PR DESCRIPTION
InputCapturer was attaching itself to the top most view by default, which can cause some problem if you have native popup show up when the app start we'll lose touch.
Now input rely on DUELLAppDelegate::rootView set by opengl so we know it will be always that input will attach itself to the right view 
